### PR TITLE
Demonstrates Android HTTPS via urllib module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Simple Kivy App to use any HTTPs request
 # author: Sirfanas
 
+Demonstrate Android HTTPS via the `urllib` is achievable thanks to the `SSL_CERT_DIR` environment variable.
+See <https://github.com/kivy/python-for-android/issues/1827>.
 
-# Compile:
-# After pulling docker Buildozer (see https://github.com/kivy/buildozer)
+
+
+## Compile:
+After pulling docker Buildozer (see https://github.com/kivy/buildozer)
+```
 docker run --interactive --tty --rm --volume ${pwd}\.buildozer\:/home/user/.buildozer --volume ${pwd}:/home/user/hostcwd --entrypoint /bin/bash kivy/buildozer
+```

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -36,7 +36,13 @@ version = 0.1
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = certifi,openssl,python3,kivy,android
+requirements =
+    android,
+    certifi,
+    kivy,
+    openssl,
+    python3,
+    requests
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/main.py
+++ b/main.py
@@ -1,25 +1,41 @@
-# coding: utf-8
-
-import certifi
+#!/usr/bin/env python3
 import os
-
-# Here's all the magic !
-os.environ['SSL_CERT_FILE'] = certifi.where()
-
-from kivy.app import App
-from kivy.uix.image import AsyncImage
+import ssl
+import unittest
 import urllib.request
 
-# Importing an "external" file to check the conf is global to the entire app
-import test
+import certifi
+import requests
+from kivy.utils import platform
 
 
-class HTTPsApp(App):
+class TestApp(unittest.TestCase):
 
-    def build(self):
-        contents = urllib.request.urlopen("https://www.google.com/").read()
-        return AsyncImage(
-            source='https://media.makeameme.org/created/its-working-oyy433.jpg'
-        )
+    URL = 'https://media.makeameme.org/created/its-working-oyy433.jpg'
+    EXPECTED_STATUS = 200
 
-HTTPsApp().run()
+    def test_requests(self):
+        """
+        The requests module handles certs seamlessly by default.
+        """
+        response = requests.get(self.URL)
+        self.assertEqual(response.status_code, self.EXPECTED_STATUS)
+
+    @unittest.skipUnless(platform == 'android', 'requires Android')
+    def test_urllib(self):
+        """
+        On Android urllib doesn't have certs by default and would crash unless
+        explicitely loaded.
+        """
+        self.assertIsNone(os.environ.get('SSL_CERT_DIR'))
+        with self.assertRaises(urllib.error.URLError) as e:
+            urllib.request.urlopen(self.URL)
+        self.assertEqual(
+            type(e.exception.args[0]), ssl.SSLCertVerificationError)
+        os.environ['SSL_CERT_FILE'] = certifi.where()
+        response = urllib.request.urlopen(self.URL)
+        self.assertEqual(response.status, self.EXPECTED_STATUS)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,7 +1,0 @@
-# coding: utf-8
-
-import urllib.request
-
-# Just to check the CA file is global I open google and display the content
-contents = urllib.request.urlopen("https://www.google.com/").read()
-print(contents)


### PR DESCRIPTION
Creates a unit test that shows setting `SSL_CERT_DIR` is mandatory.
Refs https://github.com/kivy/python-for-android/issues/1827

Running the app on Android should produce the following output:
```
06-08 02:30:30.302 30934 31115 I python  : Android kivy bootstrap done.
__name__ is __main__
06-08 02:30:30.302 30934 31115 I python  : AND: Ran string
06-08 02:30:30.302 30934 31115 I python  : Run user program, change dir
and execute entrypoint

06-08 02:30:31.094 30934 31115 I python  : [WARNING] [Config      ]
Older configuration version detected (0 instead of 21)
06-08 02:30:31.094 30934 31115 I python  : [WARNING] [Config      ]
Upgrading configuration in progress.
06-08 02:30:31.103 30934 31115 I python  : [INFO   ] [Logger      ]
Record log in
/data/user/0/org.httpsapp.httpsapp/files/app/.kivy/logs/kivy_19-06-08_0.txt
06-08 02:30:31.103 30934 31115 I python  : [INFO   ] [Kivy        ]
v1.11.0.dev0, git-d562ecc, 20190607
06-08 02:30:31.103 30934 31115 I python  : [INFO   ] [Python      ]
v3.7.1 (default, Jun  8 2019, 01:44:06)
06-08 02:30:31.103 30934 31115 I python  : [Clang 6.0.2
(https://android.googlesource.com/toolchain/clang 183abd29fc496f55
06-08 02:30:31.120 30934 31115 I python  :
/data/user/0/org.httpsapp.httpsapp/files/app/_python_bundle/site-packages/requests/models.py:176:
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop
working
06-08 02:30:31.581 30934 31115 I python  :  ..
06-08 02:30:31.582 30934 31115 I python  :
----------------------------------------------------------------------
06-08 02:30:31.582 30934 31115 I python  :  Ran 2 tests in 0.467s
06-08 02:30:31.583 30934 31115 I python  :
06-08 02:30:31.584 30934 31115 I python  :  OK
```